### PR TITLE
feat: bump toc to 12.0.5

### DIFF
--- a/ConcentrationRecharge.toc
+++ b/ConcentrationRecharge.toc
@@ -1,4 +1,4 @@
-## Interface: 120001
+## Interface: 120005
 ## Version:  @project-version@
 
 ## Title: ConcentrationRecharge


### PR DESCRIPTION
## Summary
• Updates addon interface version from 12.0.1 to 12.0.5 for compatibility with latest WoW patch

## Test plan
- [ ] Verify addon loads correctly in WoW 12.0.5
- [ ] Confirm concentration tracking still works across all supported professions

🤖 Generated with [Claude Code](https://claude.ai/code)